### PR TITLE
fix: 🐛 correct path to the logos in the footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .DS_Store
 _site
 /.quarto/
+
+**/*.quarto_ipynb

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -26,7 +26,7 @@ website:
           - text: "About ON LiMiT"
             href: eng-about.md
   page-footer:
-    center: "![](_extensions/onlimit-study/onlimit-theme/images/sdca.svg){height='40px'} ![](_extensions/onlimit-study/onlimit-theme/images/au.svg){height='40px'} ![](_extensions/onlimit-study/onlimit-theme/images/sdcc.svg){height='40px'} ![](_extensions/onlimit-study/onlimit-theme/images/sdco.svg){height='40px'} ![](_extensions/onlimit-study/onlimit-theme/images/ku.svg){height='40px'} ![](_extensions/onlimit-study/onlimit-theme/images/bispebjerg.svg){height='40px'}"
+    center: "![](/_extensions/onlimit-study/onlimit-theme/images/sdca.svg){height='40px'} ![](/_extensions/onlimit-study/onlimit-theme/images/au.svg){height='40px'} ![](/_extensions/onlimit-study/onlimit-theme/images/sdcc.svg){height='40px'} ![](/_extensions/onlimit-study/onlimit-theme/images/sdco.svg){height='40px'} ![](/_extensions/onlimit-study/onlimit-theme/images/ku.svg){height='40px'} ![](/_extensions/onlimit-study/onlimit-theme/images/bispebjerg.svg){height='40px'}"
 
 editor:
   markdown:


### PR DESCRIPTION
The footer used `_extensions/`, which meant that some pages were trying to look in their own folder for a `_extensions/` folder. So appended `/` to ensure it always starts from the root of the website.